### PR TITLE
Use print function instead of print statement in Sage files

### DIFF
--- a/src/sage/api.yaml
+++ b/src/sage/api.yaml
@@ -26,13 +26,13 @@ descr: |
     For more, see the [documentation](http://doc.sagemath.org/html/en/reference/databases/sage/databases/stein_watkins.html).
 code: |
     gen = SteinWatkinsAllData(0)
-    print gen
+    print(gen)
     C = next(gen)
-    print C.data
-    print C.leading_coefficient
-    print C.modular_degree
-    print C.rank
-    print C.isogeny_number
+    print(C.data)
+    print(C.leading_coefficient)
+    print(C.modular_degree)
+    print(C.rank)
+    print(C.isogeny_number)
 ---
 title: Tables of Zeros of the Riemann Zeta Function
 descr: |
@@ -40,5 +40,5 @@ descr: |
     For more, see the [documentation](http://doc.sagemath.org/html/en/reference/databases/sage/databases/odlyzko.html).
 code: |
     zz = zeta_zeros()
-    print len(zz)
-    print zz[12]
+    print(len(zz))
+    print(zz[12])

--- a/src/sage/files.yaml
+++ b/src/sage/files.yaml
@@ -13,7 +13,7 @@ code: |
     E = EllipticCurve([0,1])
     save(E,"/tmp/file") # A copy of "E" is now saved at /tmp/file.sobj
     E = load("/tmp/file")
-    print E
+    print(E)
 ---
 title: "Read CSV data"
 descr: |

--- a/src/sage/interact.yaml
+++ b/src/sage/interact.yaml
@@ -38,7 +38,7 @@ code: |
     f(x) = 2*x + 1
     @interact
     def f_interact(x=(0, 100)):
-        print 'f({}) = {}'.format(x, f(x))
+        print('f({}) = {}'.format(x, f(x)))
 test: false
 ---
 title: Multiple Sliders

--- a/src/sage/linearalgebra.yaml
+++ b/src/sage/linearalgebra.yaml
@@ -44,8 +44,8 @@ code: |
   A = matrix([[ 1, 2, 3, 4],
              [ 5, 6, 7, 8],
              [ 9,10,11,12]])
-  print(A[1, 3] # 2nd row, 4th element: 8)
-  print(A[:, 1] # 2nd column: [2, 6, 10] transposed)
+  print(A[1, 3]) # 2nd row, 4th element: 8
+  print(A[:, 1]) # 2nd column: [2, 6, 10] transposed
 ---
 title: Basic Arithmetic
 descr: |

--- a/src/sage/linearalgebra.yaml
+++ b/src/sage/linearalgebra.yaml
@@ -13,11 +13,11 @@ descr: |
   Look at the different parents of $v_1$ and $v_2$.
 code: |
   v1 = vector([1,2,3])
-  print v1
-  print v1.parent()
+  print(v1)
+  print(v1.parent())
   v2 = vector([-1.1, 2.2, 3])
-  print v2
-  print v2.parent()
+  print(v2)
+  print(v2.parent())
 ---
 title: Matrix
 descr: |
@@ -27,11 +27,11 @@ descr: |
   In this case here, we explicitly tell Sage that the ring is `RDF`, though.
 code: |
   m1 = matrix([[1, 2], [4, -1]])
-  print m1
-  print m1.parent()
+  print(m1)
+  print(m1.parent())
   m2 = matrix(RDF, [[1, 2], [4, -1]])
-  print m2
-  print m2.parent()
+  print(m2)
+  print(m2.parent())
 ---
 title: Accessing Elements
 descr: |
@@ -44,8 +44,8 @@ code: |
   A = matrix([[ 1, 2, 3, 4],
              [ 5, 6, 7, 8],
              [ 9,10,11,12]])
-  print A[1, 3] # 2nd row, 4th element: 8
-  print A[:, 1] # 2nd column: [2, 6, 10] transposed
+  print(A[1, 3] # 2nd row, 4th element: 8)
+  print(A[:, 1] # 2nd column: [2, 6, 10] transposed)
 ---
 title: Basic Arithmetic
 descr: |
@@ -55,9 +55,9 @@ code: |
              [ 5, 6, 7, 8],
              [ 9,10,11,12]])
   # sum of second and third column
-  print A[:, 1] + A[:, 2]
+  print(A[:, 1] + A[:, 2])
   # dot-product of first and second row (note, we have to transpose it!)
-  print A[0, :] * A[1, :].transpose()
+  print(A[0, :] * A[1, :].transpose())
 ---
 title: Elementwise Product
 descr: If you actually mean to multiply elements and not the dot-product, use the method `elementwise_product`.
@@ -86,9 +86,9 @@ descr: |
   Note, that the inverse depends on the ring!
 code: |
   m1 = matrix([[1, 2], [4, -1]])
-  print m1.inverse()
+  print(m1.inverse())
   m2 = matrix(RDF, [[1, 2], [4, -1]])
-  print ~m2
+  print(~m2)
 ---
 title: Kernel
 code: |
@@ -105,9 +105,9 @@ code: |
                    [1, -2, 1]])
   b = vector(RDF, [9, 5, -1])
   x = A.solve_right(b)
-  print "x:         {}".format(x)
-  print "check A*x: {}".format(A * x)
-  print "bashslash: {}".format(A \ b)
+  print("x:         {}".format(x))
+  print("check A*x: {}".format(A * x))
+  print("bashslash: {}".format(A \ b))
 ---
 title: Eigenvalues and Eigenvectors
 descr: |
@@ -140,10 +140,10 @@ code: |
   C = matrix([[3, 4, 5],
               [2, 3, 4],
               [1, 2, 3]])
-  print C.echelon_form()
+  print(C.echelon_form())
 
   C2 = C.change_ring(GF(2))
-  print C2
-  print C2.echelon_form()
+  print(C2)
+  print(C2.echelon_form())
 ---
 

--- a/src/sage/math.yaml
+++ b/src/sage/math.yaml
@@ -50,7 +50,7 @@ code: |
     var('x k w')
     f = x^3 * e^(k*x) * sin(w*x)
     show(f)
-    print "Differentiate f w.r.t. x"
+    print("Differentiate f w.r.t. x")
     show(f.diff(x))
 ---
 title: Functions
@@ -59,15 +59,15 @@ descr: |
 code: |
     var('x')
     f(x) = 3 * x -1
-    print f
+    print(f)
     g(x) = (1 - x)^2
-    print g
+    print(g)
     # h is a composition of f and g
     h = f(g)
-    print h
+    print(h)
     # evaluate h
-    print h(x = 3)
-    print h.subs(x = pi)
+    print(h(x = 3))
+    print(h.subs(x = pi))
 ---
 title: Substitutions
 descr: |
@@ -75,11 +75,11 @@ descr: |
 code: |
     var('x y')
     ex1 = 2*x+1
-    print ex1
-    print ex1.subs(x = 3)
-    print ex1.subs(x = pi)
+    print(ex1)
+    print(ex1.subs(x = 3))
+    print(ex1.subs(x = pi))
     ex2 = ex1.subs(x = (x + y - 1) / 2)
-    print ex2
+    print(ex2)
 ---
 title: Expressions
 descr: |
@@ -92,12 +92,12 @@ descr: |
 code: |
     var('x')
     ex = 2 * x^2 == (1 + x) / (1 - x)
-    print "full expression:             %s " % ex
+    print("full expression:             %s " % ex)
     ex2 = ex.right_hand_side()
-    print "right hand side:             %s" % ex2
-    print "operands of right hand side: %s" % ex2.operands()
+    print("right hand side:             %s" % ex2)
+    print("operands of right hand side: %s" % ex2.operands())
     ex3 = ex2.op[0] # nominator
-    print "the x inside the nominator:  %s" % ex3.op[0]
+    print("the x inside the nominator:  %s" % ex3.op[0])
 ---
 title: Polynomials
 descr: |
@@ -105,10 +105,10 @@ descr: |
 code: |
     R.<x> = PolynomialRing(QQ, "x")
     p = x^2 + 1
-    print p
-    print p.derivative()
-    print p.integral()
-    print type(p)
+    print(p)
+    print(p.derivative())
+    print(p.integral())
+    print(type(p))
 ---
 title: Limits
 descr: |
@@ -117,9 +117,9 @@ descr: |
     See [Reference/Limit](http://doc.sagemath.org/html/en/reference/calculus/sage/calculus/calculus.html#sage.calculus.calculus.limit) for more information.
 code: |
     var('x')
-    print lim((x+1)^(1/x), x = 0)
-    print lim(sqrt(x^2+1) - x, x = oo)
-    print lim(diff(abs(x),x), x = 0, dir='-')
+    print(lim((x+1)^(1/x), x = 0))
+    print(lim(sqrt(x^2+1) - x, x = oo))
+    print(lim(diff(abs(x),x), x = 0, dir='-'))
 ---
 title: Symbolic Sums
 descr: |
@@ -128,11 +128,11 @@ descr: |
 code: |
     var('k u x')
     # known limits
-    print sum(x^k, k, 1, 10)
+    print(sum(x^k, k, 1, 10))
     # up to infinity
-    print sum(1/k^4, k, 1, oo)
+    print(sum(1/k^4, k, 1, oo))
     # unknown limits
-    print sum(x^(2*k+1), k, -u, u)
+    print(sum(x^(2*k+1), k, -u, u))
 ---
 title: Taylor Series
 descr: >
@@ -140,9 +140,9 @@ descr: >
 code: |
     var('f0 k x')
     g = f0 / sinh(k*x)^4
-    print g
+    print(g)
     t = g.taylor(x, 0, 3)
-    print t
+    print(t)
 ---
 title: Formal Power Series
 descr: |
@@ -150,8 +150,8 @@ descr: |
 code: |
     var('x')
     ex = 1/ (2 - cos(x))
-    print ex
-    print ex.series(x,7)
+    print(ex)
+    print(ex.series(x,7))
 ---
 title: Fast Computations in Formal Power Series Ring
 descr: |
@@ -159,10 +159,10 @@ descr: |
 code: |
     R.<w> = QQ[[]]
     ps = w + 17/2*w^2 + 15/4*w^4 + O(w^6)
-    print ps
+    print(ps)
     (1+ps).log()
-    print r"Coefficients of $ps^1000$"
-    print (ps^1000).coefficients()
+    print(r"Coefficients of $ps^1000$")
+    print((ps^1000).coefficients())
 ---
 title: Symbolic Integrals
 descr: |
@@ -170,9 +170,9 @@ descr: |
 code: |
     var('x')
     f = x^3
-    print f.integral(x)
+    print(f.integral(x))
     # or as a function
-    print integral(x^3,x)
+    print(integral(x^3,x))
 ---
 title: Definite Integrals
 descr: |
@@ -180,9 +180,9 @@ descr: |
 code: |
     var('x k w')
     f = k * sin(w*x)
-    print f.integrate(x, 0, 1)
+    print(f.integrate(x, 0, 1))
     # or as a function
-    print integrate(1/x^2, x, 1, infinity)
+    print(integrate(1/x^2, x, 1, infinity))
 ---
 title: Laplace Transforms
 descr: |
@@ -233,8 +233,8 @@ descr: |
 code: |
     var('x')
     y = function('y')(x)
-    print desolve(diff(y,x,2) + 3*x == y, dvar = y, ics = [1,1,1])
-    print desolve(diff(y,x,2) + 3*x == y, dvar = y)
+    print(desolve(diff(y,x,2) + 3*x == y, dvar = y, ics = [1,1,1]))
+    print(desolve(diff(y,x,2) + 3*x == y, dvar = y))
 ---
 title: Slope Field
 descr: |

--- a/src/sage/numbertheory.yaml
+++ b/src/sage/numbertheory.yaml
@@ -19,42 +19,42 @@ title: |
 code: |
   R = IntegerModRing(97)
   a = R(2) / R(3)
-  print a
-  print a.rational_reconstruction()
+  print(a)
+  print(a.rational_reconstruction())
   b = R(47)
-  print b^20052005
-  print b.modulus()
-  print "is b square? {}".format(b.is_square())
+  print(b^20052005)
+  print(b.modulus())
+  print("is b square? {}".format(b.is_square()))
 ---
 title: Standard number theoretic functions
 code: |
-  print gcd(2011946, 1450942)
-  print factor(2018)
+  print(gcd(2011946, 1450942))
+  print(factor(2018))
   c = factorial(25)
-  print c
-  print [valuation(c,p) for p in prime_range(2,23)]
-  print next_prime(2005)
-  print previous_prime(2005)
-  print '%s %s %s' % (divisors(28), sum(divisors(28)), 2*28)
+  print(c)
+  print([valuation(c,p) for p in prime_range(2,23)])
+  print(next_prime(2005))
+  print(previous_prime(2005))
+  print('%s %s %s' % (divisors(28), sum(divisors(28)), 2*28))
 ---
 title: |
   `sigma(n,k)` adds up the k-th powers of the divisors of n
 code: |
-  print sigma(28,0)
-  print sigma(28,1)
-  print sigma(28,2)
+  print(sigma(28,0))
+  print(sigma(28,1))
+  print(sigma(28,2))
 ---
 title: Extended Euclidean algorithm
 code: |
   d,u,v = xgcd(12,15)
-  print "d: {d}, u: {u}, v: {v}".format(**locals())
-  print d == u*12 + v*15
+  print("d: {d}, u: {u}, v: {v}".format(**locals()))
+  print(d == u*12 + v*15)
 ---
 title: Inverse of an element mod m
 descr: This iterates from $1$ to $9$ and for each of them computes the `inverse_mod(m, 997)`.
 code: |
   for m in srange(1, 10):
-    print "m {}: {:>6d}".format(m, inverse_mod(m, 997))
+    print("m {}: {:>6d}".format(m, inverse_mod(m, 997)))
 ---
 title: "Prime divisors of an Integer"
 code: "prime_divisors(20172018)"
@@ -73,21 +73,21 @@ code: |
 title: Chinese remainder theorem
 code: |
   x = crt(2, 1, 3, 5); x
-  print x % 3 # x mod 3 = 2
-  print x % 5 # x mod 5 = 1
-  print [binomial(13,m) for m in range(14)]
-  print [binomial(13,m)%2 for m in range(14)]
-  print [kronecker(m,13) for m in range(1,13)]
+  print(x % 3 # x mod 3 = 2)
+  print(x % 5 # x mod 5 = 1)
+  print([binomial(13,m) for m in range(14)])
+  print([binomial(13,m)%2 for m in range(14)])
+  print([kronecker(m,13) for m in range(1,13)])
   n = 10000
-  print sum([moebius(m) for m in range(1,n)])
-  print Partitions(4).list()
+  print(sum([moebius(m) for m in range(1,n)]))
+  print(Partitions(4).list())
 ---
 title: "Hint: Strings to Integers"
 descr: "You can define an integer in [base 36](https://en.wikipedia.org/wiki/Base36). That way you can use the alphabet for encoding a message."
 code: |
   x = Integer('secret', base=36)
-  print x                # gives 1717162949
-  print x.str(base=36)   # gives 'secret'
+  print(x                # gives 1717162949)
+  print(x.str(base=36)   # gives 'secret')
 ---
 category: ['Mathematics', '$p$-adic Numbers']
 sortweight: 10
@@ -103,26 +103,26 @@ title: "11-adic field"
 descr: "11-adic field with capped relative precision 20"
 code: |
    K = Qp(11)
-   print K
+   print(K)
    a = K(211/17)
-   print a
+   print(a)
    b = K(3211/11^2)
-   print b
-   print a *  b
+   print(b)
+   print(a *  b)
 ---
 title: "Integral Basis"
 code: |
   R.<x> = PolynomialRing(QQ)
   K = NumberField(x^3 + x^2 - 2*x + 8, 'a')
-  print K
-  print K.integral_basis()
+  print(K)
+  print(K.integral_basis())
 ---
 title: "Ring of Integers"
 code: |
   R.<x> = PolynomialRing(QQ)
   K = NumberField(x^3 + x^2 - 2*x + 8, 'a')
-  print K
-  print K.ring_of_integers()
+  print(K)
+  print(K.ring_of_integers())
 ---
 title: "Galois Group"
 code: |

--- a/src/sage/numbertheory.yaml
+++ b/src/sage/numbertheory.yaml
@@ -73,8 +73,8 @@ code: |
 title: Chinese remainder theorem
 code: |
   x = crt(2, 1, 3, 5); x
-  print(x % 3 # x mod 3 = 2)
-  print(x % 5 # x mod 5 = 1)
+  print(x % 3) # x mod 3 = 2
+  print(x % 5) # x mod 5 = 1
   print([binomial(13,m) for m in range(14)])
   print([binomial(13,m)%2 for m in range(14)])
   print([kronecker(m,13) for m in range(1,13)])
@@ -86,8 +86,8 @@ title: "Hint: Strings to Integers"
 descr: "You can define an integer in [base 36](https://en.wikipedia.org/wiki/Base36). That way you can use the alphabet for encoding a message."
 code: |
   x = Integer('secret', base=36)
-  print(x                # gives 1717162949)
-  print(x.str(base=36)   # gives 'secret')
+  print(x)                # gives 1717162949
+  print(x.str(base=36))   # gives 'secret'
 ---
 category: ['Mathematics', '$p$-adic Numbers']
 sortweight: 10

--- a/src/sage/rings.yaml
+++ b/src/sage/rings.yaml
@@ -50,8 +50,8 @@ decr: |
   Note, how $5 * x + 10 * x + y$ evaluates to $2*x + y$.
 code: |
   GF_13.<x,y> = GF(13)[]
-  print GF_13
-  print 5 * x + 10 * x + y
+  print(GF_13)
+  print(5 * x + 10 * x + y)
 ---
 title: |
   Polynomial Ring $\QQ[x,\,y,\,z]$

--- a/src/sage/russ_plotting.yaml
+++ b/src/sage/russ_plotting.yaml
@@ -8,7 +8,7 @@ category: Plotting / 2D
 ---
 title: Basic Plot
 code: |
-  print "Basic plot: you need a variable, and a function of the variable here x*sin( x^2 )"
+  print("Basic plot: you need a variable, and a function of the variable here x*sin( x^2 )")
 
   # this defaults many many things you can control
   # here in 2 steps using plot() and show() (which can be combined into one line):
@@ -18,7 +18,7 @@ descr: Basic plot of a function, letting most options default.
 ---
 title: Upper and lower limit
 code: |
-  print "Basic plot extended with upper lower, limit on x"
+  print("Basic plot extended with upper lower, limit on x")
 
   pt    = plot( x*sin(x^2), x,  0, 6*pi )      # args in order:  function, variable, lower limit, upper limit,
   show( pt )
@@ -28,7 +28,7 @@ descr: >
 ---
 title: Many more options/arguments
 code: |
-  print "Plot with many more options/arguments, used by name that are somewhat self explanatory -- tweak values to see what they do, or google them"
+  print("Plot with many more options/arguments, used by name that are somewhat self explanatory -- tweak values to see what they do, or google them")
   # show also offers named arguments for control.
 
   pt    = plot( x*sin(x^2), x,  0, 6*pi, rgbcolor="red",  linestyle = "-",  fill=False, thickness=1, legend_label ="a legend label" )
@@ -39,7 +39,7 @@ descr: >
 ---
 title: Multiple lines/function
 code: |
-  print "Plot Multiple lines/function on plots"
+  print("Plot Multiple lines/function on plots")
   # also note that functions may be computed and put into variables outside of plot() or show()
 
   function1    = x*sin(x^2)
@@ -71,7 +71,7 @@ code: |
 ---
 title: Custom tickmarks on the axes
 code: |
-  print "Plot with ticks, LaTeX formatting at specific locations"
+  print("Plot with ticks, LaTeX formatting at specific locations")
 
   fx     = 1 * (x^2)+1
   pt     = plot( fx ,x, 0,5, ticks=[[0,1,e,pi,sqrt(20)], 5 ], tick_formatter="latex")
@@ -83,16 +83,16 @@ descr: >
 ---
 title: Using Python functions
 code: |
-  print "Plot using Python functions defined using 'def:'"
+  print("Plot using Python functions defined using 'def:'")
   # see  http://www.sagemath.org/doc/tutorial/tour_functions.html
 
   def f(z):       # this and next line define a Python function
       return z^2
 
-  print "Define plot and show it in one line of code"
+  print("Define plot and show it in one line of code")
   show(plot(f, 0, 2), figsize=[6,2])
 
-  print "Alternate syntax "
+  print("Alternate syntax ")
   z = var("z")
   show(plot(f(z), z, 0, 2), figsize=[6,2])
 descr: >
@@ -103,7 +103,7 @@ category: Plotting / 2D Advanced
 ---
 title: Implicit Plot
 code: |
-  print "Implicit plot ( here function of x, y not solved for y )"
+  print("Implicit plot ( here function of x, y not solved for y )")
 
   var ('x y')
   imp  = exp(x)==y^2
@@ -114,7 +114,7 @@ descr: >
 ---
 title: Parametric Plot
 code: |
-  print "Parametric Plot (here 3 functions)"
+  print("Parametric Plot (here 3 functions)")
   # for graphing parametric equations ( 2 functions with a common variable implying a relation between the 2 functions )
   # 3 plots all controlled by the parameter t
 
@@ -144,7 +144,7 @@ code: |
 ---
 title: Polar Plot
 code: |
-  print "Polar Plot"
+  print("Polar Plot")
 
   # Plot using polar coordinates: note that many of the options for plot() work here.
 
@@ -160,7 +160,7 @@ descr: >
 ---
 title: Slope Field
 code: |
-  print "Plot Slope Field"
+  print("Plot Slope Field")
 
   x, y = var( "x, y" )
 
@@ -188,7 +188,7 @@ code: |
   eq = diff(y, x) == - y/x - x + 2
   h = desolve(eq, y, [2, 4])
   sol(x) = h.expand()
-  print "solution:", sol
+  print("solution:", sol)
 
   # substituting the solution for y(x) in the right hand side
   substituted = eq.rhs().substitute_function(yy, sol)
@@ -200,7 +200,7 @@ code: |
 ---
 title: Vector Field
 code: |
-  print "Plot vector field"
+  print("Plot vector field")
 
   var( "x" )
   var( "y" )
@@ -219,7 +219,7 @@ descr: >
 ---
 title: List of points
 code: |
-  print "Plot of a list of points"
+  print("Plot of a list of points")
 
   # either type of list works
   dictionary_list =  {22: 3365, 27: 3295, 37: 3135, 42: 3020, 47: 2880, 52: 2735, 57: 2550}
@@ -234,7 +234,7 @@ descr: >
 ---
 title: Scatter Plot with Line
 code: |
-  print "Scatter plot and line"   # http://www.packtpub.com/article/plotting-data-sage
+  print("Scatter plot and line"   # http://www.packtpub.com/article/plotting-data-sage)
 
   # python function
   def noisy_line(m, b, x):
@@ -257,7 +257,7 @@ descr: >
 ---
 title: Contour Plot
 code: |
-  print "Contour plot"
+  print("Contour plot")
 
   # this might be improved, some explanation
 
@@ -280,7 +280,7 @@ category: Plotting / Basic Elements
 ---
 title: Points as points (plain and fancy)
 code: |
-  print "Plotting points as points ( plain and fancy )"
+  print("Plotting points as points ( plain and fancy )")
 
   plainPoints    = point([1, 1]) + point([2, 1])
   plot1  = plot( plainPoints )
@@ -302,7 +302,7 @@ code: |
 ---
 title: Line with point at the end
 code: |
-  print "Plot a line with point ( dot ) at end"
+  print("Plot a line with point ( dot ) at end")
   # computed in polar form, not required
 
   r        = 5
@@ -339,7 +339,7 @@ descr: >
 ---
 title: Arc
 code: |
-  print "Plot an Arc"
+  print("Plot an Arc")
 
   graphic   = (arc((.1,.2), 1, sector=(0,  1*pi /4)))
 
@@ -350,7 +350,7 @@ descr: >
 ---
 title: Circle
 code: |
-  print "Plot a Circle"
+  print("Plot a Circle")
 
   anGraphic = circle((0,0), .5, rgbcolor=(1,0,0),  fill=False )    # fill controls filling of circle with color
 
@@ -359,7 +359,7 @@ descr: Plot a circle.  Center, radius, color are parameters.
 ---
 title: Arrow
 code: |
-  print "Plot an Arrow"
+  print("Plot an Arrow")
 
   anGraphic = arrow((0,1), (2,3) ) # start cord, end cord as tuples
 
@@ -368,7 +368,7 @@ descr: Plot an Arrow, describe by starting and ending coordinates.
 ---
 title: Text
 code: |
-  print "Plot Text"
+  print("Plot Text")
   # text is followed by tuple for position
   aGraphic     = text("Sample Text", (5,4), rgbcolor=(1,0,0))
   show(aGraphic, aspect_ratio=1, figsize = 3)

--- a/src/sage/russ_plotting.yaml
+++ b/src/sage/russ_plotting.yaml
@@ -234,7 +234,7 @@ descr: >
 ---
 title: Scatter Plot with Line
 code: |
-  print("Scatter plot and line"   # http://www.packtpub.com/article/plotting-data-sage)
+  print("Scatter plot and line")   # http://www.packtpub.com/article/plotting-data-sage
 
   # python function
   def noisy_line(m, b, x):

--- a/src/sage/tutorial.yaml
+++ b/src/sage/tutorial.yaml
@@ -16,7 +16,7 @@ descr: >
     but that's not Python!
 code: |
     f(x) = 2*x + 1
-    print f(3)
+    print(f(3))
 ---
 title: Assignments
 descr: >
@@ -93,8 +93,8 @@ code: |
             self.nominator = nom
             self.denominator = denom
     f1 = Fraction(1, 2)
-    print f1.nominator
-    print f1.denominator
+    print(f1.nominator)
+    print(f1.denominator)
 ---
 title: Functions
 descr: |
@@ -110,21 +110,21 @@ descr: |
 
     ```
     x = 7
-    print x
+    print(x)
     f(x) = x^2
-    print x
+    print(x)
     ```
 
     will print `7` and then `x`.
 code: |
     def f(x):
         return 2*x
-    print f(11)
+    print(f(11))
 
     # this defines x to be a symbolic variable
     var('x')
     g(x) = 2 * x + 1
-    print g(21)
+    print(g(21))
 ---
 title: Symbolic Expressions
 descr: |
@@ -139,9 +139,9 @@ code: |
     var('x y')
     type(y)
     ex1 = (x + y)^2 == 1
-    print ex1
+    print(ex1)
     ex2 = x - y == 1
-    print ex2
+    print(ex2)
 ---
 title: Approximate Symbolic Expressions
 descr: >


### PR DESCRIPTION
In preparation for Python 3, I converted the print statements into print functions. I didn't know how to use the `2to3` tool here so I did it in a  more manual way.

I ran `sed -i "s/^\(\s*print\)\s\+\(.*\)/\1(\2)/g" *` in the `src/sage` directory. This fixes everything except lines with an inline comment. I then manually fixed those. 

When I ran  `make LANG=sage test`, most tests pass except I get `ZMQError: Address already in use` which seems irrelevant to what I changed since I get the same errors on the master branch. 
